### PR TITLE
Fix typo and add responsive meta tag

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -5,7 +5,7 @@
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css"
           integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
     <link rel=stylesheet type=text/css href="{{ url_for('static', filename='style.css') }}"/>
-    <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='hightlight-theme-github.css') }}" />
+    <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='highlight-theme-github.css') }}" />
     <script src="{{ url_for('static', filename='highlight.pack.js') }}"></script>
 </head>
 <body>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -2,6 +2,7 @@
 <html>
 <head>
     <title>CS Flash Cards</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css"
           integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
     <link rel=stylesheet type=text/css href="{{ url_for('static', filename='style.css') }}"/>


### PR DESCRIPTION
I noticed the tag linking `/static/highlight-theme-github.css` has a typo and fixed it.

Also, I added a responsive meta tag in head, so css can work properly in mobile devices and we can avoid zooming.