### PR TITLE
Avoid hints for an invalid password attempt

### DIFF
--- a/flash_cards.py
+++ b/flash_cards.py
@@ -260,9 +260,9 @@ def login():
     error = None
     if request.method == 'POST':
         if request.form['username'] != app.config['USERNAME']:
-            error = 'Invalid username'
+            error = 'Invalid username or password!'
         elif request.form['password'] != app.config['PASSWORD']:
-            error = 'Invalid password'
+            error = 'Invalid username or password!'
         else:
             session['logged_in'] = True
             session.permanent = True  # stay logged in


### PR DESCRIPTION
In case a (malicious) user gets a correct username, avoid showing hint
for invalid password attempts as they can guide a brute force attack.
This can be (somewhat) useful when the website is **publicly** hosted.