### PR TITLE
Enable HTML escaping for code segments

### DIFF
--- a/templates/cards.html
+++ b/templates/cards.html
@@ -57,7 +57,7 @@
                     {% if card.type == 1 %}
                         {{ card.back|replace("\n", "<br />")|safe }}
                     {% else %}
-                        <pre><code>{{ card.back|safe }}</code></pre>
+                        <pre><code>{{ card.back|escape }}</code></pre>
                     {% endif %}
                 </td>
             </tr>

--- a/templates/memorize.html
+++ b/templates/memorize.html
@@ -47,7 +47,7 @@
                                     </div>
                                 {% endif %}
                             {% else %}
-                                <pre><code>{{ card.back|safe }}</code></pre>
+                                <pre><code>{{ card.back|escape }}</code></pre>
                             {% endif %}
                         </div>
                     </div>


### PR DESCRIPTION
Currently, code segment like `vector<int>` is interpreted as `vector` and an opening `<int>` tag. Escaping the HTML for the code segment fixes this behavior.