### PR TITLE
Added docker-compose file so we don't need to run full docker execute…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3'
+
+services:
+
+  cs-flash-cards:
+    build: .
+    ports:
+      - 8000:8000
+    volumes:
+      - ./cards-empty.db:/src/db/cards.db
+#      - ./cards-jwasham-extreme.db:/src/db/cards.db
+#      - ./cards-jwasham.db:/src/db/cards.db


### PR DESCRIPTION
I'm lazy and don't like to type long commands.  Added docker-compose file to simplify running docker version of app. I can update readme if you want as well.  Volume mounts and port mapping are in the docker-compose as well.  Don't need to run `docker build...` and `docker run...` with this file. `docker-compose up -d` will build and run everything for you.  You can edit the docker-compose file to point to the correct volumes for db as well.