### PR TITLE
prevent docker exit on start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN pip install --upgrade pip \
     && pip install flask gunicorn
 
 COPY entrypoint.sh /
+RUN sed -i 's/\r$//' /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 VOLUME /src/db


### PR DESCRIPTION
Hello, on the latest version of Docker on Windows (Docker Desktop Community 2.5.0.1), after building & running docker container it exits on startup. Someone already pointed it out in the issues but I see no PR for this. Credits to

https://github.com/jwasham/computer-science-flash-cards/issues/30#issuecomment-435064915

Just so that anyone who runs the windows version doesnt run into this issue again. 

