### PR TITLE
fix requirments.txt flask 1.0 depends on Jinja2>=2.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ httplib2==0.18.0
 idna==2.1
 ipaddress==1.0.16
 itsdangerous==0.24
-Jinja2==2.9.4
+Jinja2==2.11.1
 jsonschema==2.5.1
 lockfile==0.12.2
 MarkupSafe==0.23


### PR DESCRIPTION
The conflict is caused by:
    The user requested Jinja2==2.9.4
    flask 1.0 depends on Jinja2>=2.10