### PR TITLE
Dockerfile: Update python version and deprecated maintainer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM python:3.5
-MAINTAINER Tinpee <tinpee.dev@gmail.com>
+FROM python:3.9
+LABEL maintainer="Tinpee <tinpee.dev@gmail.com>"
 
 ADD . /src
 WORKDIR /src
@@ -14,5 +14,3 @@ VOLUME /src/db
 
 EXPOSE 8000
 CMD ["/entrypoint.sh"]
-
-


### PR DESCRIPTION
* Update python version of docker from 3.5 to 3.9 as 3.5 is EOL
* Replace deprecated `MAINTAINER` with `LABEL` (see https://docs.docker.com/engine/reference/builder/#maintainer-deprecated)