### PR TITLE
Fix config problem with gunicorn

### DIFF
--- a/flash_cards.py
+++ b/flash_cards.py
@@ -17,7 +17,7 @@ def load_config():
     ))
     app.config.from_envvar('CARDS_SETTINGS', silent=True)
 
-if __name__ == "__main__":
+if __name__ == "__main__" or __name__ == "flash_cards":
     load_config()
 
 def connect_db():


### PR DESCRIPTION
* the `__name__` variable is not `__main__` when the app is opened with gunicorn.